### PR TITLE
サンプルアプリを多言語化(日本語、英語)にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,5 @@ group :test do
 end
 
 gem 'carrierwave'
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.7)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.4.2)
       actionpack (= 7.0.4.2)
       activesupport (= 7.0.4.2)
@@ -275,6 +278,7 @@ DEPENDENCIES
   jbuilder
   puma (~> 5.0)
   rails (~> 7.0.4)
+  rails-i18n
   rubocop-fjord
   rubocop-rails
   selenium-webdriver

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :set_locale
+
+  private
+    def set_locale
+      I18n.locale = params[:locale] || I18n.default_locale
+    end
+
+    def default_url_options
+      { locale: I18n.locale }
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,11 +4,12 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
 
   private
-    def set_locale
-      I18n.locale = params[:locale] || I18n.default_locale
-    end
 
-    def default_url_options
-      { locale: I18n.locale }
-    end
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  def default_url_options
+    { locale: I18n.locale }
+  end
 end

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,21 +1,21 @@
 <div id="<%= dom_id book %>">
   <p>
-    <strong><%= t 'books.title' %>:</strong>
+    <strong><%= t('activerecord.attributes.books.title') %>:</strong>
     <%= book.title %>
   </p>
 
   <p>
-    <strong><%= t 'books.memo' %>:</strong>
+    <strong><%= t('activerecord.attributes.books.memo') %>:</strong>
     <%= book.memo %>
   </p>
 
   <p>
-    <strong><%= t 'books.author' %>:</strong>
+    <strong><%= t('activerecord.attributes.books.author') %>:</strong>
     <%= book.author %>
   </p>
 
   <p>
-    <strong><%= t 'books.picture' %>:</strong>
+    <strong><%= t('activerecord.attributes.books.picture') %>:</strong>
     <%= image_tag(book.picture_url) if book.picture.present? %>
   </p>
 

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,16 +1,16 @@
 <div id="<%= dom_id book %>">
   <p>
-    <strong>Title:</strong>
+    <strong><%= t 'books.title' %>:</strong>
     <%= book.title %>
   </p>
 
   <p>
-    <strong>Memo:</strong>
+    <strong><%= t 'books.memo' %>:</strong>
     <%= book.memo %>
   </p>
 
   <p>
-    <strong>Author:</strong>
+    <strong><%= t 'books.author' %>:</strong>
     <%= book.author %>
   </p>
 

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -1,21 +1,21 @@
 <div id="<%= dom_id book %>">
   <p>
-    <strong><%= t('activerecord.attributes.books.title') %>:</strong>
+    <strong><%= Book.human_attribute_name(:title) %>:</strong>
     <%= book.title %>
   </p>
 
   <p>
-    <strong><%= t('activerecord.attributes.books.memo') %>:</strong>
+    <strong><%= Book.human_attribute_name(:memo) %>:</strong>
     <%= book.memo %>
   </p>
 
   <p>
-    <strong><%= t('activerecord.attributes.books.author') %>:</strong>
+    <strong><%= Book.human_attribute_name(:author) %>:</strong>
     <%= book.author %>
   </p>
 
   <p>
-    <strong><%= t('activerecord.attributes.books.picture') %>:</strong>
+    <strong><%= Book.human_attribute_name(:picture) %>:</strong>
     <%= image_tag(book.picture_url) if book.picture.present? %>
   </p>
 

--- a/app/views/books/_book.html.erb
+++ b/app/views/books/_book.html.erb
@@ -15,7 +15,7 @@
   </p>
 
   <p>
-    <strong>Picture:</strong>
+    <strong><%= t 'books.picture' %>:</strong>
     <%= image_tag(book.picture_url) if book.picture.present? %>
   </p>
 

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -12,22 +12,22 @@
   <% end %>
 
   <div>
-    <%= form.label t 'books.title', style: "display: block" %>
+    <%= form.label t('activerecord.attributes.books.title'), style: "display: block" %>
     <%= form.text_field :title %>
   </div>
 
   <div>
-    <%= form.label t 'books.memo', style: "display: block" %>
+    <%= form.label t('activerecord.attributes.books.memo'), style: "display: block" %>
     <%= form.text_area :memo %>
   </div>
 
   <div>
-    <%= form.label t 'books.author', style: "display: block" %>
+    <%= form.label t('activerecord.attributes.books.author'), style: "display: block" %>
     <%= form.text_field :author %>
   </div>
 
   <div>
-    <%= form.label t 'books.picture', style: "display: block" %>
+    <%= form.label t('activerecord.attributes.books.picture'), style: "display: block" %>
     <%= form.file_field :picture %>
   </div>
 

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -12,22 +12,22 @@
   <% end %>
 
   <div>
-    <%= form.label :title, style: "display: block" %>
+    <%= form.label t 'books.title', style: "display: block" %>
     <%= form.text_field :title %>
   </div>
 
   <div>
-    <%= form.label :memo, style: "display: block" %>
+    <%= form.label t 'books.memo', style: "display: block" %>
     <%= form.text_area :memo %>
   </div>
 
   <div>
-    <%= form.label :author, style: "display: block" %>
+    <%= form.label t 'books.author', style: "display: block" %>
     <%= form.text_field :author %>
   </div>
 
   <div>
-    <%= form.label :picture, style: "display: block" %>
+    <%= form.label t 'books.picture', style: "display: block" %>
     <%= form.file_field :picture %>
   </div>
 

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -12,22 +12,22 @@
   <% end %>
 
   <div>
-    <%= form.label t('activerecord.attributes.books.title'), style: "display: block" %>
+    <%= form.label Book.human_attribute_name(:title), style: "display: block" %>
     <%= form.text_field :title %>
   </div>
 
   <div>
-    <%= form.label t('activerecord.attributes.books.memo'), style: "display: block" %>
+    <%= form.label Book.human_attribute_name(:memo), style: "display: block" %>
     <%= form.text_area :memo %>
   </div>
 
   <div>
-    <%= form.label t('activerecord.attributes.books.author'), style: "display: block" %>
+    <%= form.label Book.human_attribute_name(:author), style: "display: block" %>
     <%= form.text_field :author %>
   </div>
 
   <div>
-    <%= form.label t('activerecord.attributes.books.picture'), style: "display: block" %>
+    <%= form.label Book.human_attribute_name(:picture), style: "display: block" %>
     <%= form.file_field :picture %>
   </div>
 

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,10 +1,10 @@
-<h1><%= t('activerecord.attributes.books.edit_title',resource: t('activerecord.attributes.books.title')) %></h1>
+<h1><%= t('views.common.edit_title',resource: Book.model_name.human) %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to t('activerecord.attributes.books.show',resource: t('activerecord.attributes.books.title')), @book %> |
-  <%= link_to t('activerecord.attributes.books.back'), books_path %>
+  <%= link_to t('views.common.show',resource: Book.model_name.human), @book %> |
+  <%= link_to t('views.common.back'), books_path %>
 </div>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,10 +1,10 @@
-<h1><%= t('activerecord.attributes.books.edit_title') %></h1>
+<h1><%= t('activerecord.attributes.books.edit_title',resource: t('activerecord.attributes.books.title')) %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to t('activerecord.attributes.books.show'), @book %> |
+  <%= link_to t('activerecord.attributes.books.show',resource: t('activerecord.attributes.books.title')), @book %> |
   <%= link_to t('activerecord.attributes.books.back'), books_path %>
 </div>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,10 +1,10 @@
-<h1>Editing book</h1>
+<h1><%=t('books.edit_title')%></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to "Show this book", @book %> |
-  <%= link_to "Back to books", books_path %>
+  <%= link_to t('books.show_book'), @book %> |
+  <%= link_to t('books.back_book'), books_path %>
 </div>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,10 +1,10 @@
-<h1><%= t('books.edit_title') %></h1>
+<h1><%= t('activerecord.attributes.books.edit_title') %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to t('books.show_book'), @book %> |
-  <%= link_to t('books.back_book'), books_path %>
+  <%= link_to t('activerecord.attributes.books.show'), @book %> |
+  <%= link_to t('activerecord.attributes.books.back'), books_path %>
 </div>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,4 +1,4 @@
-<h1><%=t('books.edit_title')%></h1>
+<h1><%= t('books.edit_title') %></h1>
 
 <%= render "form", book: @book %>
 

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p style="color: green"><%= notice %></p>
 
-<h1><%= t('books.index_title') %></h1>
+<h1><%= t('activerecord.attributes.books.index_title') %></h1>
 
 <div id="books">
   <% @books.each do |book| %>
     <%= render book %>
     <p>
-      <%= link_to t('books.show_book'), book %>
+      <%= link_to t('activerecord.attributes.books.show'), book %>
     </p>
   <% end %>
 </div>
 
-<%= link_to t('books.new_book'), new_book_path %>
+<%= link_to t('activerecord.attributes.books.new'), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p style="color: green"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%=t('books.index_title')%></h1>
 
 <div id="books">
   <% @books.each do |book| %>
     <%= render book %>
     <p>
-      <%= link_to "Show this book", book %>
+      <%= link_to t('books.show_book'), book %>
     </p>
   <% end %>
 </div>
 
-<%= link_to "New book", new_book_path %>
+<%= link_to t('books.new_book'), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p style="color: green"><%= notice %></p>
 
-<h1><%= t('activerecord.attributes.books.index_title',resource: t('activerecord.attributes.books.title')) %></h1>
+<h1><%= t('views.common.index_title',resource: Book.model_name.human) %></h1>
 
 <div id="books">
   <% @books.each do |book| %>
     <%= render book %>
     <p>
-      <%= link_to t('activerecord.attributes.books.show',resource: t('activerecord.attributes.books.title')), book %>
+      <%= link_to t('views.common.show',resource: Book.model_name.human), book %>
     </p>
   <% end %>
 </div>
 
-<%= link_to t('activerecord.attributes.books.new',resource: t('activerecord.attributes.books.title')), new_book_path %>
+<%= link_to t('views.common.new',resource: Book.model_name.human), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,6 +1,6 @@
 <p style="color: green"><%= notice %></p>
 
-<h1><%=t('books.index_title')%></h1>
+<h1><%= t('books.index_title') %></h1>
 
 <div id="books">
   <% @books.each do |book| %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,14 +1,14 @@
 <p style="color: green"><%= notice %></p>
 
-<h1><%= t('activerecord.attributes.books.index_title') %></h1>
+<h1><%= t('activerecord.attributes.books.index_title',resource: t('activerecord.attributes.books.title')) %></h1>
 
 <div id="books">
   <% @books.each do |book| %>
     <%= render book %>
     <p>
-      <%= link_to t('activerecord.attributes.books.show'), book %>
+      <%= link_to t('activerecord.attributes.books.show',resource: t('activerecord.attributes.books.title')), book %>
     </p>
   <% end %>
 </div>
 
-<%= link_to t('activerecord.attributes.books.new'), new_book_path %>
+<%= link_to t('activerecord.attributes.books.new',resource: t('activerecord.attributes.books.title')), new_book_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,9 +1,9 @@
-<h1>New book</h1>
+<h1><%=t('books.edit_title')%></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to "Back to books", books_path %>
+  <%= link_to t('books.back_book'), books_path %>
 </div>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,9 +1,9 @@
-<h1><%= t('books.edit_title') %></h1>
+<h1><%= t('activerecord.attributes.books.new_title') %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to t('books.back_book'), books_path %>
+  <%= link_to t('activerecord.attributes.books.back'), books_path %>
 </div>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%= t('activerecord.attributes.books.new_title') %></h1>
+<h1><%= t('activerecord.attributes.books.new_title',resource: t('activerecord.attributes.books.title')) %></h1>
 
 <%= render "form", book: @book %>
 

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,9 +1,9 @@
-<h1><%= t('activerecord.attributes.books.new_title',resource: t('activerecord.attributes.books.title')) %></h1>
+<h1><%= t('views.common.new_title',resource: Book.model_name.human) %></h1>
 
 <%= render "form", book: @book %>
 
 <br>
 
 <div>
-  <%= link_to t('activerecord.attributes.books.back'), books_path %>
+  <%= link_to t('views.common.back'), books_path %>
 </div>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,4 +1,4 @@
-<h1><%=t('books.edit_title')%></h1>
+<h1><%= t('books.edit_title') %></h1>
 
 <%= render "form", book: @book %>
 

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -3,8 +3,8 @@
 <%= render @book %>
 
 <div>
-  <%= link_to t('books.edit_book'), edit_book_path(@book) %> |
-  <%= link_to t('books.back_book'), books_path %>
+  <%= link_to t('activerecord.attributes.books.edit', resource: t('activerecord.attributes.books.title')), edit_book_path(@book) %> |
+  <%= link_to t('activerecord.attributes.books.back'), books_path %>
 
-  <%= button_to t('books.destroy_book'), @book, method: :delete %>
+  <%= button_to t('activerecord.attributes.books.destroy', resource: t('activerecord.attributes.books.title')), @book, method: :delete %>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -3,8 +3,8 @@
 <%= render @book %>
 
 <div>
-  <%= link_to t('activerecord.attributes.books.edit', resource: t('activerecord.attributes.books.title')), edit_book_path(@book) %> |
-  <%= link_to t('activerecord.attributes.books.back'), books_path %>
+  <%= link_to t('views.common.edit', resource: Book.model_name.human), edit_book_path(@book) %> |
+  <%= link_to t('views.common.back'), books_path %>
 
-  <%= button_to t('activerecord.attributes.books.destroy', resource: t('activerecord.attributes.books.title')), @book, method: :delete %>
+  <%= button_to t('views.common.destroy', resource: Book.model_name.human), @book, method: :delete %>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -3,8 +3,8 @@
 <%= render @book %>
 
 <div>
-  <%= link_to "Edit this book", edit_book_path(@book) %> |
-  <%= link_to "Back to books", books_path %>
+  <%= link_to t('books.edit_book'), edit_book_path(@book) %> |
+  <%= link_to t('books.back_book'), books_path %>
 
-  <%= button_to "Destroy this book", @book, method: :delete %>
+  <%= button_to t('books.destroy_book'), @book, method: :delete %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ module BooksApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
-    config.i18n.load_path += Dir[Rails.root.join('locales', '*.{rb,yml}')]
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module BooksApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    config.i18n.load_path += Dir[Rails.root.join('locales', '*.{rb,yml}')]
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/books.en.yml
+++ b/config/locales/books.en.yml
@@ -1,0 +1,21 @@
+---
+en:
+  activerecord:
+    models:
+      book: Book
+    attributes:
+      book: 
+        title: Title
+        memo: Memo
+        author: Author
+        picture: Picture
+  views: 
+    common:
+        show: "Show %{resource}"
+        new: "New %{resource}"
+        edit: "Edit this %{resource}"
+        back: Back to book
+        destroy: "Destroy this %{resource}"
+        new_title: "New %{resource}"
+        index_title: "%{resource}s"
+        edit_title: "Edit %{resource}"

--- a/config/locales/books.ja.yml
+++ b/config/locales/books.ja.yml
@@ -3,15 +3,15 @@ ja:
   activerecord:
     attributes:
       books: 
-        title: 書籍名
+        title: 書籍
         memo: メモ
         author: 著者
         picture: 画像
-        show: 書籍を閲覧
-        new: 書籍を登録
-        edit: 書籍を編集
+        show: "%{resource}を閲覧"
+        new: "%{resource}を登録"
+        edit: "%{resource}を編集"
         back: 前に戻る
-        destroy: 書籍を削除
-        new_title: 新しい書籍
-        index_title: 書籍一覧
-        edit_title: 書籍を編集
+        destroy: "%{resource}を削除"
+        new_title: "新しい%{resource}"
+        index_title: "%{resource}一覧"
+        edit_title: "%{resource}を編集"

--- a/config/locales/books.ja.yml
+++ b/config/locales/books.ja.yml
@@ -1,12 +1,16 @@
 ---
 ja: 
   activerecord:
+    models:
+      books: 書籍
     attributes:
       books: 
-        title: 書籍
+        title: タイトル
         memo: メモ
         author: 著者
         picture: 画像
+  views: 
+    common:
         show: "%{resource}を閲覧"
         new: "%{resource}を登録"
         edit: "%{resource}を編集"

--- a/config/locales/books.ja.yml
+++ b/config/locales/books.ja.yml
@@ -2,9 +2,9 @@
 ja: 
   activerecord:
     models:
-      books: 書籍
+      book: 書籍
     attributes:
-      books: 
+      book: 
         title: タイトル
         memo: メモ
         author: 著者

--- a/config/locales/books.ja.yml
+++ b/config/locales/books.ja.yml
@@ -1,0 +1,16 @@
+---
+ja:  
+  books:
+    title: 書籍名
+    memo: メモ
+    author: 著者
+    picture: 画像
+    show_book: 書籍を閲覧
+    new_book: 書籍を登録
+    edit_book: 書籍を編集
+    back_book: 前に戻る
+    destroy_book: 書籍を削除
+    new_title: 新しい書籍
+    index_title: 書籍一覧
+    edit_title: 書籍を編集
+

--- a/config/locales/books.ja.yml
+++ b/config/locales/books.ja.yml
@@ -1,16 +1,17 @@
 ---
-ja:  
-  books:
-    title: 書籍名
-    memo: メモ
-    author: 著者
-    picture: 画像
-    show_book: 書籍を閲覧
-    new_book: 書籍を登録
-    edit_book: 書籍を編集
-    back_book: 前に戻る
-    destroy_book: 書籍を削除
-    new_title: 新しい書籍
-    index_title: 書籍一覧
-    edit_title: 書籍を編集
-
+ja: 
+  activerecord:
+    attributes:
+      books: 
+        title: 書籍名
+        memo: メモ
+        author: 著者
+        picture: 画像
+        show: 書籍を閲覧
+        new: 書籍を登録
+        edit: 書籍を編集
+        back: 前に戻る
+        destroy: 書籍を削除
+        new_title: 新しい書籍
+        index_title: 書籍一覧
+        edit_title: 書籍を編集

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,4 +219,12 @@ en:
     title: Title
     memo: Memo
     author: Author
-
+    picture: Picture
+    show_book: Show book
+    new_book: New book
+    edit_book: Edit this book
+    back_book: Back to books
+    destroy_book: Destroy this book
+    new_title: New book
+    index_title: Books
+    edit_title: Edit Title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,16 +215,3 @@ en:
       long: "%B %d, %Y %H:%M"
       short: "%d %b %H:%M"
     pm: pm
-  books:
-    title: Title
-    memo: Memo
-    author: Author
-    picture: Picture
-    show_book: Show book
-    new_book: New book
-    edit_book: Edit this book
-    back_book: Back to books
-    destroy_book: Destroy this book
-    new_title: New book
-    index_title: Books
-    edit_title: Edit Title

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,222 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
+---
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validation failed: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    - 
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    - 
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about %{count} hour
+        other: about %{count} hours
+      about_x_months:
+        one: about %{count} month
+        other: about %{count} months
+      about_x_years:
+        one: about %{count} year
+        other: about %{count} years
+      almost_x_years:
+        one: almost %{count} year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than %{count} second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over %{count} year
+        other: over %{count} years
+      x_seconds:
+        one: "%{count} second"
+        other: "%{count} seconds"
+      x_minutes:
+        one: "%{count} minute"
+        other: "%{count} minutes"
+      x_days:
+        one: "%{count} day"
+        other: "%{count} days"
+      x_months:
+        one: "%{count} month"
+        other: "%{count} months"
+      x_years:
+        one: "%{count} year"
+        other: "%{count} years"
+    prompts:
+      second: Second
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      in: must be in %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is %{count} character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is %{count} character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be %{count} character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: "%{count} error prohibited this %{model} from being saved"
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm
+  books:
+    title: Title
+    memo: Memo
+    author: Author
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -185,3 +185,13 @@ ja:
     title: 書籍名
     memo: メモ
     author: 著者
+    picture: 画像
+    show_book: 書籍を閲覧
+    new_book: 書籍を登録
+    edit_book: 書籍を編集
+    back_book: 前に戻る
+    destroy_book: 書籍を削除
+    new_title: 新しい書籍
+    index_title: 書籍一覧
+    edit_title: 書籍を編集
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -181,17 +181,3 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
-  books:
-    title: 書籍名
-    memo: メモ
-    author: 著者
-    picture: 画像
-    show_book: 書籍を閲覧
-    new_book: 書籍を登録
-    edit_book: 書籍を編集
-    back_book: 前に戻る
-    destroy_book: 書籍を削除
-    new_title: 新しい書籍
-    index_title: 書籍一覧
-    edit_title: 書籍を編集
-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,187 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後
+  books:
+    title: 書籍名
+    memo: メモ
+    author: 著者

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   resources :books
+
+  scope "(:locale)", locale: /en|ja/ do
+    resources :books
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
- 英語と日本語の翻訳をconfig/locales配下のYAMLファイルに定義する
- 各画面の表示を翻訳ファイルから取得して表示できるようにする
- デフォルトの表示言語を英語または日本語に切り替えることで、実際に画面の表示が英語と日本語に切り替わるようにする