### PR TITLE
コメント機能を追加する

### DIFF
--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Books::CommentsController < CommentsController
   before_action :set_commentable
 

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -10,7 +10,6 @@ class Books::CommentsController < CommentsController
   end
 
   def render_commentable_show
-    @book = @commentable
     render 'books/show'
   end
 end

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,5 +1,4 @@
 class Books::CommentsController < CommentsController
-  binding.irb
   before_action :set_commentable
 
   private

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,15 @@
+class Books::CommentsController < CommentsController
+  binding.irb
+  before_action :set_commentable
+
+  private
+
+  def set_commentable
+    @commentable = Book.find(params[:book_id])
+  end
+
+  def render_commentable_show
+    @book = @commentable
+    render 'books/show'
+  end
+end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -9,7 +9,10 @@ class BooksController < ApplicationController
   end
 
   # GET /books/1 or /books/1.json
-  def show; end
+  def show; 
+    @comments = @book.comments
+    @comment = Comment.new
+  end
 
   # GET /books/new
   def new

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -9,7 +9,7 @@ class BooksController < ApplicationController
   end
 
   # GET /books/1 or /books/1.json
-  def show; 
+  def show
     @comments = @book.comments
     @comment = Comment.new
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,7 +12,6 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
     else
-      @comments = @commentable.comments
       render_commentable_show
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,39 @@
+class CommentsController < ApplicationController
+  before_action :set_comment, only: %i[edit update destroy]
+
+  def edit; end
+
+  def create
+    @comment = @commentable.comments.build(comment_params)
+    @comment.user = current_user
+    if @comment.save
+      redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      @comments = @commentable.comments
+      render_commentable_show
+    end
+  end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to polymorphic_path(@commentable), notice: t('controllers.common.notice_update', name: Comment.model_name.human)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @comment.destroy
+    redirect_to polymorphic_path(@commentable), notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -40,8 +40,8 @@ class CommentsController < ApplicationController
   end
 
   def authorize_comment
-    unless current_user == @comment.user
-      redirect_to root_path
-    end
+    return if current_user == @comment.user
+
+    redirect_to root_path
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[edit update destroy]
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -39,7 +39,7 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
   end
 
-  def set_authorized_report
+  def set_authorized_comment
     @comment = current_user.comments.find(params[:id])
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,6 +2,7 @@
 
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[edit update destroy]
+  before_action :authorize_comment, only: %i[edit update destroy]
 
   def edit; end
 
@@ -37,5 +38,11 @@ class CommentsController < ApplicationController
 
   def set_comment
     @comment = Comment.find(params[:id])
+  end
+
+  def authorize_comment
+    unless current_user == @comment.user
+      redirect_to root_path
+    end
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,7 +2,7 @@
 
 class CommentsController < ApplicationController
   before_action :set_comment, only: %i[edit update destroy]
-  before_action :authorize_comment, only: %i[edit update destroy]
+  before_action :set_authorized_report, only: %i[edit update destroy]
 
   def edit; end
 
@@ -39,9 +39,7 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
   end
 
-  def authorize_comment
-    return if current_user == @comment.user
-
-    redirect_to root_path
+  def set_authorized_report
+    @comment = current_user.comments.find(params[:id])
   end
 end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Reports::CommentsController < CommentsController
   before_action :set_commentable
 

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,14 @@
+class Reports::CommentsController < CommentsController
+  before_action :set_commentable
+
+  private
+
+  def set_commentable
+    @commentable = Report.find(params[:report_id])
+  end
+
+  def render_commentable_show
+    @report = @commentable
+    render 'reports/show'
+  end
+end

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -10,7 +10,6 @@ class Reports::CommentsController < CommentsController
   end
 
   def render_commentable_show
-    @report = @commentable
     render 'reports/show'
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,57 @@
+class ReportsController < ApplicationController
+  before_action :set_report, only: %i[show]
+  before_action :correct_user, only: %i[edit update destroy]
+
+  def index
+    @reports = Report.order(:id).page(params[:page])
+  end
+
+  def show
+    @comments = @report.comments
+    @comment = Comment.new
+  end
+
+  def new
+    @report = Report.new
+  end
+
+  def edit; end
+
+  def create
+    @report = current_user.reports.build(report_params)
+
+    if @report.save
+      redirect_to report_url(@report), notice: t('controllers.common.notice_create', name: Report.model_name.human)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @report.update(report_params)
+      redirect_to report_url(@report), notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @report.destroy
+
+    redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
+  end
+
+  private
+
+  def set_report
+    @report = Report.find(params[:id])
+  end
+
+  def report_params
+    params.require(:report).permit(:title, :content)
+  end
+
+  def correct_user
+    @report = current_user.reports.find_by!(id: params[:id])
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,7 +2,7 @@
 
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[show]
-  before_action :correct_user, only: %i[edit update destroy]
+  before_action :authorize_report, only: %i[edit update destroy]
 
   def index
     @reports = Report.order(:id).page(params[:page])
@@ -53,7 +53,7 @@ class ReportsController < ApplicationController
     params.require(:report).permit(:title, :content)
   end
 
-  def correct_user
-    @report = current_user.reports.find_by!(id: params[:id])
+  def authorize_report
+    @report = current_user.reports.find(params[:id])
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,7 +2,7 @@
 
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[show]
-  before_action :authorize_report, only: %i[edit update destroy]
+  before_action :set_authorized_report, only: %i[edit update destroy]
 
   def index
     @reports = Report.order(:id).page(params[:page])
@@ -53,7 +53,7 @@ class ReportsController < ApplicationController
     params.require(:report).permit(:title, :content)
   end
 
-  def authorize_report
+  def set_authorized_report
     @report = current_user.reports.find(params[:id])
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[show]
   before_action :correct_user, only: %i[edit update destroy]

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,6 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :commentable, polymorphic: true

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :commentable, polymorphic: true
+
+  validates :content, presence: true
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,8 @@
+class Report < ApplicationRecord
+  belongs_to :user
+  has_many :comments, as: :commentable, dependent: :destroy
+
+  validates :user_id, presence: true
+  validates :title, presence: true
+  validates :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ApplicationRecord
   end
 
   has_many :reports, dependent: :destroy
-
   has_many :comments, dependent: :destroy
 
   def name_or_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,12 @@ class User < ApplicationRecord
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [150, 150]
   end
+
+  has_many :reports, dependent: :destroy
+
+  has_many :comments, dependent: :destroy
+  
+  def name_or_email
+    name.empty? ? email : name
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :reports, dependent: :destroy
 
   has_many :comments, dependent: :destroy
-  
+
   def name_or_email
     name.empty? ? email : name
   end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,5 +1,7 @@
 <h1><%= t('views.common.title_show', name: Book.model_name.human) %></h1>
 
+<% book = @commentable %>
+
 <div class="show-item">
   <%= render @book %>
 </div>
@@ -10,6 +12,8 @@
 
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </nav>
+
+<% comments = @book.comments %>
 
 <%= render 'comments/comments', commentable: @book, comments: @comments %>
 <%= render 'comments/form', commentable: @book, comment: @comment %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,7 +1,5 @@
 <h1><%= t('views.common.title_show', name: Book.model_name.human) %></h1>
 
-<% book = @commentable %>
-
 <div class="show-item">
   <%= render @book %>
 </div>
@@ -13,7 +11,5 @@
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </nav>
 
-<% comments = @book.comments %>
-
-<%= render 'comments/comments', commentable: @book, comments: @comments %>
+<%= render 'comments/comments', commentable: @book %>
 <%= render 'comments/form', commentable: @book, comment: @comment %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -10,3 +10,6 @@
 
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </nav>
+
+<%= render 'comments/comments', commentable: @book, comments: @comments %>
+<%= render 'comments/form', commentable: @book, comment: @comment %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,5 +1,5 @@
 <h2><%= Comment.model_name.human %></h2>
-<% comments.each do |comment| %>
+<% commentable.comments.each do |comment| %>
   <% if comment.persisted? %>
     <p>
       <strong><%= Comment.human_attribute_name(:content) %>:</strong> <%= comment.content %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -9,7 +9,7 @@
       <%= comment.user.name_or_email %>
     </p>
     <p>
-      <strong><%= Comment.human_attribute_name(:created_at) %>:</strong> <%= comment.created_at %>
+      <strong><%= Comment.human_attribute_name(:created_at) %>:</strong> <%= l(comment.created_at) %>
     </p>
     <% if current_user == comment.user %>
       <%= form_with model: [commentable, comment], url: edit_polymorphic_path([commentable, comment]), method: :get do |f| %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,0 +1,23 @@
+<h2><%= Comment.model_name.human %></h2>
+<% comments.each do |comment| %>
+  <% if comment.persisted? %>
+    <p>
+      <strong><%= Comment.human_attribute_name(:content) %>:</strong> <%= comment.content %>
+    </p>
+    <p>
+      <strong><%= User.model_name.human %>: </strong>
+      <%= comment.user.name_or_email %>
+    </p>
+    <p>
+      <strong><%= Comment.human_attribute_name(:created_at) %>:</strong> <%= comment.created_at %>
+    </p>
+    <% if current_user == comment.user %>
+      <%= form_with model: [commentable, comment], url: edit_polymorphic_path([commentable, comment]), method: :get do |f| %>
+        <%= f.submit t('views.common.edit') %>
+      <% end %>
+      <%= form_with model: [commentable, comment], method: :delete, data: { confirm: t('views.common.delete_confirm') } do |f| %>
+        <%= f.submit t('views.common.destroy') %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -13,10 +13,10 @@
     </p>
     <% if current_user == comment.user %>
       <%= form_with model: [commentable, comment], url: edit_polymorphic_path([commentable, comment]), method: :get do |f| %>
-        <%= f.submit t('views.common.edit') %>
+        <%= f.submit Comment.human_attribute_name(:edit) %>
       <% end %>
       <%= form_with model: [commentable, comment], method: :delete, data: { confirm: t('views.common.delete_confirm') } do |f| %>
-        <%= f.submit t('views.common.destroy') %>
+        <%= f.submit Comment.human_attribute_name(:destroy) %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_with model: [commentable, comment] do |f| %>
+  <% if comment.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= I18n.t("errors.messages.not_saved",
+                  count: comment.errors.count,
+                  resource: comment.class.model_name.human.downcase) %>
+      </h2>
+      <ul>
+        <% comment.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :content %>
+    <%= f.text_area :content, required: true %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -15,7 +15,7 @@
   <% end %>
 
   <div class="field">
-    <%= f.label :content %>
+    <%= f.label Comment.human_attribute_name(:content) %>
     <%= f.text_area :content, required: true %>
   </div>
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,18 +1,5 @@
 <%= form_with model: [commentable, comment] do |f| %>
-  <% if comment.errors.any? %>
-    <div id="error_explanation">
-      <h2>
-        <%= I18n.t("errors.messages.not_saved",
-                  count: comment.errors.count,
-                  resource: comment.class.model_name.human.downcase) %>
-      </h2>
-      <ul>
-        <% comment.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'shared/error_messages', object: comment %>
 
   <div class="field">
     <%= f.label Comment.human_attribute_name(:content) %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t('views.common.title_edit', name: Comment.model_name.human) %></h1>
+
+<%= render 'comments/form', commentable: @commentable, comment: @comment %>
+
+<%= link_to t('views.common.back'), @commentable %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'comments/form', commentable: @commentable, comment: @comment %>
 
-<%= link_to t('views.common.back'), @commentable %>
+<%= link_to t('views.common.back',name: Comment.model_name.human), @commentable %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,14 +1,1 @@
-<% if resource.errors.any? %>
-  <div id="error_explanation">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase) %>
-    </h2>
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render 'shared/error_messages', object: resource %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
             <%= link_to User.model_name.human, users_path %>
           </li>
           <li>
-            <%= link_to Report.model_name.human, reports_path %> 
+            <%= link_to Report.model_name.human, reports_path %>
           </li>
         </ul>
         <div class="title">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,9 @@
           <li>
             <%= link_to User.model_name.human, users_path %>
           </li>
+          <li>
+            <%= link_to Report.model_name.human, reports_path %> 
+          </li>
         </ul>
         <div class="title">
           <%# html_safeを使っているが、XSSは発生しないのを確認済み %>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with(model: report) do |form| %>
+  <% if report.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= I18n.t("errors.messages.not_saved",
+                  count: report.errors.count,
+                  resource: report.class.model_name.human.downcase) %>
+      </h2>
+
+      <ul>
+        <% report.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -16,12 +16,12 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :title %>
+    <%= form.label Report.human_attribute_name(:title) %>
     <%= form.text_field :title %>
   </div>
 
   <div class="field">
-    <%= form.label :content %>
+    <%= form.label Report.human_attribute_name(:content) %>
     <%= form.text_area :content %>
   </div>
 

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,20 @@
+<h1>Edit Report</h1>
+
+<%= form_with model: @report, local: true do |form| %>
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>
+
+<%= link_to 'Show', @report %> |
+<%= link_to 'Back', reports_path %>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,20 +1,5 @@
-<h1>Edit Report</h1>
+<h1><%= Report.human_attribute_name(:edit_report) %></h1>
 
-<%= form_with model: @report, local: true do |form| %>
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
-  </div>
+<%= render 'form', report: @report %>
 
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
-<% end %>
-
-<%= link_to 'Show', @report %> |
-<%= link_to 'Back', reports_path %>
+<%= link_to t('views.common.show',name: Report.model_name.human), @report %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,9 @@
+<h1>Reports</h1>
+
+<ul>
+  <% @reports.each do |report| %>
+    <li><%= link_to report.title, report_path(report) %></li>
+  <% end %>
+</ul>
+
+<%= link_to 'New Report', new_report_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Reports</h1>
+<h1><%= Report.model_name.human %></h1>
 
 <ul>
   <% @reports.each do |report| %>
@@ -6,4 +6,4 @@
   <% end %>
 </ul>
 
-<%= link_to 'New Report', new_report_path %>
+<%= link_to Report.human_attribute_name(:new_report), new_report_path %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,19 +1,5 @@
-<h1>New Report</h1>
+<h1><%= Report.human_attribute_name(:new_report) %></h1>
 
-<%= form_with model: @report, local: true do |form| %>
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
-  </div>
+<%= render 'form', report: @report %>
 
-  <div class="field">
-    <%= form.label :content %>
-    <%= form.text_area :content %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
-  </div>
-<% end %>
-
-<%= link_to 'Back', reports_path %>
+<%= link_to t('views.common.back',name: Report.model_name.human), reports_path %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,19 @@
+<h1>New Report</h1>
+
+<%= form_with model: @report, local: true do |form| %>
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :content %>
+    <%= form.text_area :content %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>
+
+<%= link_to 'Back', reports_path %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -5,10 +5,8 @@
 <%= render 'comments/comments', commentable: @report, comments: @comments %>
 
 <% if current_user == @report.user %>
-  <%= button_to t('views.common.edit'), edit_report_path(@report), method: :get %>
-  <%= button_to t('views.common.destroy'), report_path(@report), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+  <%= button_to t('views.common.edit',name: Report.model_name.human), edit_report_path(@report), method: :get %>
+  <%= button_to t('views.common.destroy',name: Report.model_name.human), report_path(@report), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
 <% end %>
-<%= link_to t('views.common.back'), reports_path %>
+<%= link_to t('views.common.back',name: Report.model_name.human), reports_path %>
 
-<%= link_to 'Edit', edit_report_path(@report) %> |
-<%= link_to 'Back', reports_path %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,11 +1,8 @@
 <h1><%= @report.title %></h1>
 <p><%= @report.content %></p>
 
-<% report = @commentable %>
-<% comments = @report.comments %>
-
 <%= render 'comments/form', commentable: @report, comment: @comment %>
-<%= render 'comments/comments', commentable: @report, comments: @comments %>
+<%= render 'comments/comments', commentable: @report %>
 
 <% if current_user == @report.user %>
   <%= button_to t('views.common.edit',name: Report.model_name.human), edit_report_path(@report), method: :get %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -9,4 +9,3 @@
   <%= button_to t('views.common.destroy',name: Report.model_name.human), report_path(@report), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
 <% end %>
 <%= link_to t('views.common.back',name: Report.model_name.human), reports_path %>
-

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,6 +1,9 @@
 <h1><%= @report.title %></h1>
 <p><%= @report.content %></p>
 
+<% report = @commentable %>
+<% comments = @report.comments %>
+
 <%= render 'comments/form', commentable: @report, comment: @comment %>
 <%= render 'comments/comments', commentable: @report, comments: @comments %>
 

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,14 @@
+<h1><%= @report.title %></h1>
+<p><%= @report.content %></p>
+
+<%= render 'comments/form', commentable: @report, comment: @comment %>
+<%= render 'comments/comments', commentable: @report, comments: @comments %>
+
+<% if current_user == @report.user %>
+  <%= button_to t('views.common.edit'), edit_report_path(@report), method: :get %>
+  <%= button_to t('views.common.destroy'), report_path(@report), method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+<% end %>
+<%= link_to t('views.common.back'), reports_path %>
+
+<%= link_to 'Edit', edit_report_path(@report) %> |
+<%= link_to 'Back', reports_path %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,14 @@
+<% if object.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                count: object.errors.count,
+                resource: object.class.model_name.human.downcase) %>
+    </h2>
+    <ul>
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -29,4 +29,3 @@ ja:
         new_report: 日報を作成
         edit_report: 日報を編集
         edit: 編集
-        

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,6 +3,8 @@ ja:
     models:
       book: 本
       user: ユーザ
+      comment: コメント
+      report: 日報
 
     attributes:
       book:
@@ -16,3 +18,15 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         avatar: ユーザ画像
+      comment:
+        content: 内容
+        edit: 編集
+        destroy: 削除
+        created_at: 投稿日時
+      report:
+        title: タイトル
+        content: 内容
+        new_report: 日報を作成
+        edit_report: 日報を編集
+        edit: 編集
+        

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,13 @@ Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'
-  resources :books
-  resources :users, only: %i(index show)
+
+  resources :books do
+    resources :comments, only: %i[create destroy edit update], module: :books
+  end
+  resources :reports do
+    resources :comments, only: %i[create destroy edit update], module: :reports
+  end
+
+  resources :users, only: %i[index show]
 end

--- a/db/migrate/20230821080501_create_comments.rb
+++ b/db/migrate/20230821080501_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :commentable, polymorphic: true, null: false
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230822064848_create_reports.rb
+++ b/db/migrate/20230822064848_create_reports.rb
@@ -1,0 +1,10 @@
+class CreateReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reports do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230822070620_add_user_id_to_reports.rb
+++ b/db/migrate/20230822070620_add_user_id_to_reports.rb
@@ -1,0 +1,5 @@
+class AddUserIdToReports < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :reports, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20230911125932_add_not_null_constraint_to_reports.rb
+++ b/db/migrate/20230911125932_add_not_null_constraint_to_reports.rb
@@ -1,0 +1,6 @@
+class AddNotNullConstraintToReports < ActiveRecord::Migration[7.0]
+  def change
+    change_column :reports, :title, :string, null: false
+    change_column :reports, :content, :text, null: false
+  end
+end

--- a/db/migrate/20230911130233_add_not_null_constraint_to_comments.rb
+++ b/db/migrate/20230911130233_add_not_null_constraint_to_comments.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToComments < ActiveRecord::Migration[7.0]
+  def change
+    change_column :comments, :content, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_22_070620) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_130233) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_22_070620) do
     t.integer "user_id", null: false
     t.string "commentable_type", null: false
     t.integer "commentable_id", null: false
-    t.text "content"
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
@@ -60,8 +60,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_22_070620) do
   end
 
   create_table "reports", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
+    t.string "title", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_21_080501) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_22_070620) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,6 +59,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_080501) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -78,4 +87,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_080501) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_21_080501) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -46,6 +46,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
     t.datetime "updated_at", null: false
     t.string "author"
     t.string "picture"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "commentable_type", null: false
+    t.integer "commentable_id", null: false
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -66,4 +77,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_070626) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
 end


### PR DESCRIPTION
- reports（日報）が投稿できるようにする
    - reports（日報） の CRUD （一覧、個別、作成、編集、削除）の機能を追加する
    - 入力項目はタイトルと本文だけで良い
    - 日報を更新・削除できるのはその日報を投稿した本人のみ
- book, reportそれぞれにコメントが付けられるようにする（コメント機能のイメージはフィヨルドブートキャンプのアプリbootcampの日報とコメントを参考にする）
    - 本と日報の各詳細画面からコメントを投稿できるようにする
    - コメントを削除できるのはそのコメントを投稿した本人のみ
    - 投稿したコメントは本と日報の各詳細画面から確認できる。投稿した内容に加えて、投稿したユーザーの名前（未入力ならメアド）と投稿日時も表示する
- 作成したコメントを削除できるようにする
- ポリモーフィック関連を使ってbookに付くコメントとreportに付くコメントを共通のコードで動くようにする