### PR TITLE
日報の言及機能を追加する

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -37,7 +37,6 @@ class ReportsController < ApplicationController
     end
   end
 
-
   def destroy
     ActiveRecord::Base.transaction do
       @report.remove_mentions

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -38,7 +38,7 @@ class ReportsController < ApplicationController
   
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   rescue ActiveRecord::InvalidForeignKey
-    redirect_to reports_url, alert: '日報を削除できませんでした。'
+    redirect_to reports_url, alert: t('controllers.common.notice_not_destroy', name: Report.model_name.human)
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -38,9 +38,7 @@ class ReportsController < ApplicationController
   end
 
   def destroy
-    ActiveRecord::Base.transaction do
-      @report.destroy
-    end
+    @report.destroy
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -40,8 +40,6 @@ class ReportsController < ApplicationController
 
   def destroy
     ActiveRecord::Base.transaction do
-      ReportMention.where(mentioning_report: @report).destroy_all
-      ReportMention.where(mentioned_report: @report).destroy_all
       @report.destroy
     end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -58,8 +58,3 @@ class ReportsController < ApplicationController
     params.require(:report).permit(:title, :content)
   end
 end
-
-def extract_mentioned_report_ids(text)
-  url_pattern = %r{http://localhost:3000/reports/(\d+)}
-  text.scan(url_pattern).flatten.map(&:to_i)
-end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,7 +21,7 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.new(report_params)
     if @report.save
-      @report.save_report_and_mention_with_content(@report.content)
+      @report.save_report_and_mention_with_content
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :new, status: :unprocessable_entity
@@ -30,7 +30,7 @@ class ReportsController < ApplicationController
 
   def update
     if @report.update(report_params)
-      @report.save_report_and_mention_with_content(@report.content)
+      @report.save_report_and_mention_with_content
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -43,9 +43,6 @@ class ReportsController < ApplicationController
       @report.destroy
     end
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
-  rescue StandardError => e
-    Rails.logger.error "Error during destroy action: #{e.message}"
-    redirect_to reports_url, alert: t('controllers.common.notice_not_destroy', name: Report.model_name.human)
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -39,7 +39,6 @@ class ReportsController < ApplicationController
 
   def destroy
     ActiveRecord::Base.transaction do
-      @report.remove_mentions
       @report.destroy
     end
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -19,27 +19,26 @@ class ReportsController < ApplicationController
   def edit; end
 
   def create
-    @report = current_user.reports.new(report_params)
-
-    if @report.save
-      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
-    else
-      render :new, status: :unprocessable_entity
-    end
+    @report = current_user.reports.new(report_params)        
+    save_report_and_mention(:new)
   end
 
   def update
     if @report.update(report_params)
-      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-    else
-      render :edit, status: :unprocessable_entity
+      save_report_and_mention(:edit)    
     end
   end
 
   def destroy
-    @report.destroy
-
+    ActiveRecord::Base.transaction do
+      ReportMention.where(mentioning_report: @report).destroy_all
+      ReportMention.where(mentioned_report: @report).destroy_all
+      @report.destroy
+    end
+  
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
+  rescue ActiveRecord::InvalidForeignKey
+    redirect_to reports_url, alert: '日報を削除できませんでした。'
   end
 
   private
@@ -51,4 +50,26 @@ class ReportsController < ApplicationController
   def report_params
     params.require(:report).permit(:title, :content)
   end
+end
+
+def extract_mentioned_report_ids(text)
+  url_pattern = /http:\/\/localhost:3000\/reports\/(\d+)/
+  text.scan(url_pattern).flatten.map(&:to_i)
+end
+
+
+def save_report_and_mention(view)
+  if @report.save
+    mentioned_report_ids = extract_mentioned_report_ids(@report.content)
+    mentioned_reports = Report.where(id: mentioned_report_ids)
+    
+    mentioned_reports.each do |mentioned_report|
+      mentioned_report.mentioned_reports << @report
+      mentioned_report.save
+    end
+
+    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+  else
+    render view, status: :unprocessable_entity
+  end  
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -40,6 +40,7 @@ class ReportsController < ApplicationController
 
   def destroy
     ActiveRecord::Base.transaction do
+      @report.remove_mentions
       @report.destroy
     end
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -42,9 +42,9 @@ class ReportsController < ApplicationController
     ActiveRecord::Base.transaction do
       @report.destroy
     end
-
     redirect_to reports_url, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
-  rescue ActiveRecord::InvalidForeignKey
+  rescue StandardError => e
+    Rails.logger.error "Error during destroy action: #{e.message}"
     redirect_to reports_url, alert: t('controllers.common.notice_not_destroy', name: Report.model_name.human)
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -64,8 +64,10 @@ def save_report_and_mention(view)
     mentioned_reports = Report.where(id: mentioned_report_ids)
     
     mentioned_reports.each do |mentioned_report|
-      mentioned_report.mentioned_reports << @report
-      mentioned_report.save
+      unless mentioned_report.mentioned_reports.include?(@report)
+        mentioned_report.mentioned_reports << @report
+        mentioned_report.save
+      end
     end
 
     redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -26,7 +26,7 @@ class Report < ApplicationRecord
     text.scan(url_pattern).flatten.map(&:to_i).uniq
   end
 
-  def save_report_and_mention_with_content(content)
+  def save_report_and_mention_with_content
     ActiveRecord::Base.transaction do
       save!
       mentioned_report_ids = extract_mentioned_report_ids(content)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -35,10 +35,10 @@ class Report < ApplicationRecord
       new_mentioned_report_ids = mentioned_report_ids - existing_mentioned_report_ids
       delete_target_report_ids = existing_mentioned_report_ids - mentioned_report_ids
 
-      ReportMention.where(mentioned_report_id: id, mentioning_report_id: delete_target_report_ids).find_each(&:destroy)
+      ReportMention.where(mentioned_report_id: id, mentioning_report_id: delete_target_report_ids).find_each(&:destroy!)
 
       new_mentioned_report_ids.each do |mentioned_report_id|
-        ReportMention.create(mentioned_report_id: id, mentioning_report_id: mentioned_report_id)
+        ReportMention.create!(mentioned_report_id: id, mentioning_report_id: mentioned_report_id)
       end
     end
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -17,4 +17,16 @@ class Report < ApplicationRecord
   def created_on
     created_at.to_date
   end
+
+  def save_report_and_mention_with_content(content)
+    mentioned_report_ids = extract_mentioned_report_ids(content)
+    mentioned_reports = Report.where(id: mentioned_report_ids)
+
+    mentioned_reports.each do |mentioned_report|
+      unless mentioned_report.mentioned_reports.include?(self)
+        mentioned_report.mentioned_reports << self
+        mentioned_report.save
+      end
+    end
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,8 +7,11 @@ class Report < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true, allow_blank: true
 
-  has_many :mentions, class_name: 'ReportMention', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
-  has_many :mentioned_reports, through: :mentions, source: :mentioned_report
+  has_many :mentioning, class_name: 'ReportMention', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
+  has_many :mentioned_reports, through: :mentioning, source: :mentioned_report, inverse_of: :mentioned
+
+  has_many :mentioned, class_name: 'ReportMention', foreign_key: 'mentioned_report_id', dependent: :destroy, inverse_of: :mentioned_report
+  has_many :mentioning_reports, through: :mentioned, source: :mentioning_report, inverse_of: :mentioning
 
   def editable?(target_user)
     user == target_user
@@ -22,7 +25,6 @@ class Report < ApplicationRecord
     ActiveRecord::Base.transaction do
       begin
         save
-
         mentioned_report_ids = extract_mentioned_report_ids(content)
         mentioned_reports = Report.where(id: mentioned_report_ids)
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -7,7 +7,7 @@ class Report < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true, allow_blank: true
 
-  has_many :mentions, class_name: "ReportMention", foreign_key: "mentioning_report_id"
+  has_many :mentions, class_name: 'ReportMention', foreign_key: 'mentioning_report_id', dependent: :destroy, inverse_of: :mentioning_report
   has_many :mentioned_reports, through: :mentions, source: :mentioned_report
 
   def editable?(target_user)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -36,10 +36,8 @@ class Report < ApplicationRecord
       mentioned_reports_to_add = Report.where(id: new_mentioned_report_ids)
 
       mentioned_reports.each do |mentioned_report|
-        unless mentioned_reports_to_add.include?(mentioned_report)
-          mentioned_reports.delete(mentioned_report)
-          mentioned_report.mentioned_reports.delete(self)
-        end
+        mentioned_reports.delete(mentioned_report)
+        mentioned_report.mentioned_reports.delete(self)
       end
 
       mentioned_reports_to_add.each do |mentioned_report|

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -43,4 +43,10 @@ class Report < ApplicationRecord
     Rails.logger.error "Error during save_report_and_mention_with_content: #{e.message}"
     raise ActiveRecord::Rollback
   end
+
+  def remove_mentions
+    mentioned_reports.each do |mentioned_report|
+      mentioned_report.mentioned_reports.delete(self)
+    end
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -34,8 +34,6 @@ class Report < ApplicationRecord
             mentioned_report.save
           end
         end
-      rescue StandardError => e
-        raise ActiveRecord::Rollback
       end
     end
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -35,10 +35,10 @@ class Report < ApplicationRecord
       new_mentioned_report_ids = mentioned_report_ids - existing_mentioned_report_ids
       delete_target_report_ids = existing_mentioned_report_ids - mentioned_report_ids
 
-      ReportMention.where(mentioning_report_id: id, mentioned_report_id: delete_target_report_ids).find_each(&:destroy)
+      ReportMention.where(mentioned_report_id: id, mentioning_report_id: delete_target_report_ids).find_each(&:destroy)
 
       new_mentioned_report_ids.each do |mentioned_report_id|
-        ReportMention.create(mentioning_report_id: mentioned_report_id, mentioned_report_id: id)
+        ReportMention.create(mentioned_report_id: id, mentioning_report_id: mentioned_report_id)
       end
     end
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -33,12 +33,19 @@ class Report < ApplicationRecord
       existing_mentioned_report_ids = mentioned_reports.pluck(:id)
 
       new_mentioned_report_ids = mentioned_report_ids - existing_mentioned_report_ids
-      mentioned_reports = Report.where(id: new_mentioned_report_ids)
+      mentioned_reports_to_add = Report.where(id: new_mentioned_report_ids)
 
       mentioned_reports.each do |mentioned_report|
+        unless mentioned_reports_to_add.include?(mentioned_report)
+          mentioned_reports.delete(mentioned_report)
+          mentioned_report.mentioned_reports.delete(self)
+        end
+      end
+
+      mentioned_reports_to_add.each do |mentioned_report|
         unless mentioned_report.mentioned_reports.include?(self)
+          mentioned_reports << mentioned_report
           mentioned_report.mentioned_reports << self
-          mentioned_report.save!
         end
       end
     end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -30,7 +30,10 @@ class Report < ApplicationRecord
     ActiveRecord::Base.transaction do
       save!
       mentioned_report_ids = extract_mentioned_report_ids(content)
-      mentioned_reports = Report.where(id: mentioned_report_ids)
+      existing_mentioned_report_ids = mentioned_reports.pluck(:id)
+
+      new_mentioned_report_ids = mentioned_report_ids - existing_mentioned_report_ids
+      mentioned_reports = Report.where(id: new_mentioned_report_ids)
 
       mentioned_reports.each do |mentioned_report|
         unless mentioned_report.mentioned_reports.include?(self)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -39,9 +39,6 @@ class Report < ApplicationRecord
         end
       end
     end
-  rescue ActiveRecord::RecordInvalid => e
-    Rails.logger.error "Error during save_report_and_mention_with_content: #{e.message}"
-    raise ActiveRecord::Rollback
   end
 
   def remove_mentions

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -43,10 +43,4 @@ class Report < ApplicationRecord
       end
     end
   end
-
-  def remove_mentions
-    mentioned_reports.each do |mentioned_report|
-      mentioned_report.mentioned_reports.delete(self)
-    end
-  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,7 +5,10 @@ class Report < ApplicationRecord
   has_many :comments, as: :commentable, dependent: :destroy
 
   validates :title, presence: true
-  validates :content, presence: true
+  validates :content, presence: true, allow_blank: true
+
+  has_many :mentions, class_name: "ReportMention", foreign_key: "mentioning_report_id"
+  has_many :mentioned_reports, through: :mentions, source: :mentioned_report
 
   def editable?(target_user)
     user == target_user

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -23,7 +23,7 @@ class Report < ApplicationRecord
 
   def extract_mentioned_report_ids(text)
     url_pattern = %r{http://localhost:3000/reports/(\d+)}
-    text.scan(url_pattern).flatten.map(&:to_i)
+    text.scan(url_pattern).flatten.map(&:to_i).uniq
   end
 
   def save_report_and_mention_with_content(content)

--- a/app/models/report_mention.rb
+++ b/app/models/report_mention.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 class ReportMention < ApplicationRecord
-  belongs_to :mentioning_report, class_name: "Report", foreign_key: "mentioning_report_id"
-  belongs_to :mentioned_report, class_name: "Report", foreign_key: "mentioned_report_id"
+  belongs_to :mentioning_report, class_name: 'Report', inverse_of: :mentions
+  belongs_to :mentioned_report, class_name: 'Report', inverse_of: :mentioned_reports
 end

--- a/app/models/report_mention.rb
+++ b/app/models/report_mention.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ReportMention < ApplicationRecord
-  belongs_to :mentioning_report, class_name: 'Report', inverse_of: :mentions
-  belongs_to :mentioned_report, class_name: 'Report', inverse_of: :mentioned_reports
+  belongs_to :mentioning_report, class_name: 'Report', inverse_of: :mentioning
+  belongs_to :mentioned_report, class_name: 'Report', inverse_of: :mentioned
 end

--- a/app/models/report_mention.rb
+++ b/app/models/report_mention.rb
@@ -1,0 +1,4 @@
+class ReportMention < ApplicationRecord
+  belongs_to :mentioning_report, class_name: "Report", foreign_key: "mentioning_report_id"
+  belongs_to :mentioned_report, class_name: "Report", foreign_key: "mentioned_report_id"
+end

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -16,3 +16,10 @@
     <%= button_to t('views.common.destroy', name: Report.model_name.human.downcase), @report, method: :delete %>
   <% end %>
 </nav>
+
+<h2>この日報に言及している日報</h2>
+<ul>
+  <% @report.mentioned_reports.each do |mentioned_report| %>
+    <li><%= link_to mentioned_report.title, report_path(mentioned_report) %></li>
+  <% end %>
+</ul>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 </nav>
 
-<h2>この日報に言及している日報</h2>
+<h2><%=t('views.common.report_mention', name: Report.model_name.human.downcase) %></h2>
 <ul>
   <% @report.mentioned_reports.each do |mentioned_report| %>
     <li><%= link_to mentioned_report.title, report_path(mentioned_report) %></li>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 </nav>
 
-<h2><%=t('views.common.report_mention', name: Report.model_name.human.downcase) %></h2>
+<h2><%= t('views.common.report_mention', name: Report.model_name.human.downcase) %></h2>
 <ul>
   <% @report.mentioned_reports.each do |mentioned_report| %>
     <li><%= link_to mentioned_report.title, report_path(mentioned_report) %></li>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -196,6 +196,7 @@ ja:
       validation_error: "%{errors}があるため、この%{name}は保存できませんでした"
       title_show: "%{name}の詳細"
       sign_out: ログアウト
+      report_mention: この日報に言及している日報
     pagination:
       first: '« 最初'
       last: '最後 »'
@@ -207,6 +208,7 @@ ja:
       notice_create: "%{name}が作成されました。"
       notice_update: "%{name}が更新されました。"
       notice_destroy: "%{name}が削除されました。"
+      notice_not_destroy: "%{name}が削除されませんでした。"
   layouts:
     menu:
       menu: メニュー

--- a/db/migrate/20230905053836_create_report_mentions.rb
+++ b/db/migrate/20230905053836_create_report_mentions.rb
@@ -3,8 +3,9 @@ class CreateReportMentions < ActiveRecord::Migration[7.0]
     create_table :report_mentions do |t|
       t.references :mentioning_report, null: false, foreign_key: { to_table: :reports, on_delete: :cascade }
       t.references :mentioned_report, null: false, foreign_key: { to_table: :reports, on_delete: :cascade }
-            
+
       t.timestamps
     end
+    add_index :report_mentions, [:mentioning_report_id, :mentioned_report_id], unique: true, name: 'index_report_mentions_on_reports'
   end
 end

--- a/db/migrate/20230905053836_create_report_mentions.rb
+++ b/db/migrate/20230905053836_create_report_mentions.rb
@@ -1,0 +1,10 @@
+class CreateReportMentions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :report_mentions do |t|
+      t.references :mentioning_report, null: false, foreign_key: { to_table: :reports, on_delete: :cascade }
+      t.references :mentioned_report, null: false, foreign_key: { to_table: :reports, on_delete: :cascade }
+            
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230922040531_add_unique_index_to_report_mentions.rb
+++ b/db/migrate/20230922040531_add_unique_index_to_report_mentions.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexToReportMentions < ActiveRecord::Migration[7.0]
-  def change
-    add_index :report_mentions, [:mentioning_report_id, :mentioned_report_id], unique: true, name: 'index_report_mentions_on_reports'
-  end
-end

--- a/db/migrate/20230922040531_add_unique_index_to_report_mentions.rb
+++ b/db/migrate/20230922040531_add_unique_index_to_report_mentions.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToReportMentions < ActiveRecord::Migration[7.0]
+  def change
+    add_index :report_mentions, [:mentioning_report_id, :mentioned_report_id], unique: true, name: 'index_report_mentions_on_reports'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_094327) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_020200) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -74,7 +74,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_094327) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "mentions"
     t.index ["user_id"], name: "index_reports_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_094327) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,12 +59,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "report_mentions", force: :cascade do |t|
+    t.integer "mentioning_report_id", null: false
+    t.integer "mentioned_report_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mentioned_report_id"], name: "index_report_mentions_on_mentioned_report_id"
+    t.index ["mentioning_report_id"], name: "index_report_mentions_on_mentioning_report_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "mentions"
     t.index ["user_id"], name: "index_reports_on_user_id"
   end
 
@@ -87,5 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "report_mentions", "reports", column: "mentioned_report_id"
+  add_foreign_key "report_mentions", "reports", column: "mentioning_report_id"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_020200) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_22_040531) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_020200) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["mentioned_report_id"], name: "index_report_mentions_on_mentioned_report_id"
+    t.index ["mentioning_report_id", "mentioned_report_id"], name: "index_report_mentions_on_reports", unique: true
     t.index ["mentioning_report_id"], name: "index_report_mentions_on_mentioning_report_id"
   end
 

--- a/test/fixtures/report_mentions.yml
+++ b/test/fixtures/report_mentions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  mentioning_report: one
+  mentioned_report: one
+
+two:
+  mentioning_report: two
+  mentioned_report: two

--- a/test/models/report_mention_test.rb
+++ b/test/models/report_mention_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ReportMentionTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/report_mention_test.rb
+++ b/test/models/report_mention_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReportMentionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- どの日報からリンクを貼られたかがわかる「日報の言及機能」を作成する
    - e.g. Aさんの日報の本文テキストにBさんの日報のURL（ http://localhost:3000/reports/44 など）が含まれていると、Bさんの日報に「この日報に言及している日報」としてAさんの日報が表示される
    - 日報の新規作成時だけでなく更新時や削除時も言及が更新される（本文テキストから日報のURLがなくなったら言及もなくなる）